### PR TITLE
Add initial route tests and pytest dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,9 @@ spotipy = "^2.23.0"
 python-dotenv = "^1.0.1"
 authlib = "^1.3.0"
 
+[tool.poetry.group.dev.dependencies]
+pytest = "^7.4"
+
 
 [build-system]
 requires = ["poetry-core"]

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,0 +1,28 @@
+import os
+from importlib import reload
+
+import pytest
+
+
+@pytest.fixture
+def client(monkeypatch):
+    monkeypatch.setenv('SPOTIFY_CLIENT_ID', 'dummy')
+    monkeypatch.setenv('SPOTIFY_CLIENT_SECRET', 'dummy')
+    monkeypatch.setenv('APP_SECRET_KEY', 'testing-secret')
+    import app.app as app_module
+    reload(app_module)
+    app_module.app.config['TESTING'] = True
+    with app_module.app.test_client() as client:
+        yield client
+
+
+def test_index_redirects_to_login(client):
+    response = client.get('/')
+    assert response.status_code == 302
+    assert '/login' in response.headers['Location']
+
+
+def test_login_redirects(client):
+    response = client.get('/login')
+    assert response.status_code == 302
+    assert 'accounts.spotify.com' in response.headers['Location']


### PR DESCRIPTION
## Summary
- add pytest as a dev dependency
- create simple tests covering the index and login routes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'spotipy')*

------
https://chatgpt.com/codex/tasks/task_e_687da1640a488331a28ba395e8759572