### PR TITLE
Persist Spotify tokens in session

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -1,8 +1,10 @@
 import os
+import time
+
 import spotipy
 from dotenv import load_dotenv
 from authlib.integrations.flask_client import OAuth
-from flask import Flask, redirect, request, url_for
+from flask import Flask, redirect, request, session, url_for
 from spotify_api_services import (
     get_user, get_user_playlists, get_playlist, get_playlist_items,
     get_playlist_cover_image, get_track, get_several_tracks, get_saved_tracks,
@@ -56,6 +58,17 @@ def login():
 @app.route('/authorize')
 def authorize():
     token_info = spotify.authorize_access_token()
+    if token_info is None:
+        return redirect(url_for('login'))
+
+    token_info = token_info.copy()
+    if 'expires_at' not in token_info:
+        expires_in = token_info.get('expires_in')
+        if expires_in is not None:
+            token_info['expires_at'] = int(time.time()) + int(expires_in)
+
+    session['spotify_token'] = token_info
+
     sp = spotipy.Spotify(auth=token_info['access_token'])
 
     # Fetch and print all Spotify data
@@ -91,42 +104,56 @@ def authorize():
 @app.route('/user')
 def user():
     sp = create_spotify_client()
+    if sp is None:
+        return redirect(url_for('login'))
     user_info = get_user(sp)
     return user_info
 
 @app.route('/user/playlists')
 def user_playlists():
     sp = create_spotify_client()
+    if sp is None:
+        return redirect(url_for('login'))
     playlists = get_user_playlists(sp)
     return {"playlists": playlists}
 
 @app.route('/playlist/<playlist_id>')
 def playlist(playlist_id):
     sp = create_spotify_client()
+    if sp is None:
+        return redirect(url_for('login'))
     playlist_info = get_playlist(sp, playlist_id)
     return playlist_info
 
 @app.route('/playlist/<playlist_id>/items')
 def playlist_items(playlist_id):
     sp = create_spotify_client()
+    if sp is None:
+        return redirect(url_for('login'))
     items = get_playlist_items(sp, playlist_id)
     return {"items": items}
 
 @app.route('/playlist/<playlist_id>/cover')
 def playlist_cover(playlist_id):
     sp = create_spotify_client()
+    if sp is None:
+        return redirect(url_for('login'))
     cover_image = get_playlist_cover_image(sp, playlist_id)
     return {"cover_image": cover_image}
 
 @app.route('/track/<track_id>')
 def track(track_id):
     sp = create_spotify_client()
+    if sp is None:
+        return redirect(url_for('login'))
     track_info = get_track(sp, track_id)
     return track_info
 
 @app.route('/tracks')
 def several_tracks():
     sp = create_spotify_client()
+    if sp is None:
+        return redirect(url_for('login'))
     # Assuming track IDs are passed as query parameters
     track_ids = request.args.getlist('ids')
     tracks_info = get_several_tracks(sp, track_ids)
@@ -135,12 +162,16 @@ def several_tracks():
 @app.route('/user/saved_tracks')
 def saved_tracks():
     sp = create_spotify_client()
+    if sp is None:
+        return redirect(url_for('login'))
     tracks = get_saved_tracks(sp)
     return {"saved_tracks": tracks}
 
 @app.route('/audio_features')
 def audio_features():
     sp = create_spotify_client()
+    if sp is None:
+        return redirect(url_for('login'))
     # Assuming track IDs are passed as query parameters
     track_ids = request.args.getlist('ids')
     features = get_several_audio_features(sp, track_ids)
@@ -149,30 +180,73 @@ def audio_features():
 @app.route('/track/<track_id>/audio_features')
 def track_audio_features(track_id):
     sp = create_spotify_client()
+    if sp is None:
+        return redirect(url_for('login'))
     features = get_track_audio_features(sp, track_id)
     return {"audio_features": features}
 
 @app.route('/track/<track_id>/audio_analysis')
 def track_audio_analysis(track_id):
     sp = create_spotify_client()
+    if sp is None:
+        return redirect(url_for('login'))
     analysis = get_track_audio_analysis(sp, track_id)
     return analysis
 
 @app.route('/user/top/<type>')
 def user_top_items(type):
     sp = create_spotify_client()
+    if sp is None:
+        return redirect(url_for('login'))
     top_items = get_user_top_items(sp, type)
     return {"top_items": top_items}
 
 @app.route('/user/followed_artists')
 def followed_artists():
     sp = create_spotify_client()
+    if sp is None:
+        return redirect(url_for('login'))
     artists = get_followed_artists(sp)
     return {"followed_artists": artists}
 
 def create_spotify_client():
-    token_info = spotify.authorize_access_token()
-    return spotipy.Spotify(auth=token_info['access_token'])
+    token_info = session.get('spotify_token')
+    if not token_info:
+        return None
+
+    expires_at = token_info.get('expires_at')
+    if expires_at is None:
+        expires_in = token_info.get('expires_in')
+        if expires_in is not None:
+            expires_at = int(time.time()) + int(expires_in)
+            token_info['expires_at'] = expires_at
+            session['spotify_token'] = token_info
+
+    if expires_at is not None and expires_at <= int(time.time()):
+        refresh_token = token_info.get('refresh_token')
+        if not refresh_token:
+            session.pop('spotify_token', None)
+            return None
+
+        refreshed_token = spotify.refresh_token(
+            spotify.access_token_url,
+            refresh_token=refresh_token,
+        )
+        if 'refresh_token' not in refreshed_token and refresh_token:
+            refreshed_token['refresh_token'] = refresh_token
+        if 'expires_at' not in refreshed_token:
+            expires_in = refreshed_token.get('expires_in')
+            if expires_in is not None:
+                refreshed_token['expires_at'] = int(time.time()) + int(expires_in)
+        session['spotify_token'] = refreshed_token
+        token_info = refreshed_token
+
+    access_token = token_info.get('access_token')
+    if not access_token:
+        session.pop('spotify_token', None)
+        return None
+
+    return spotipy.Spotify(auth=access_token)
 
 def fetch_and_print_spotify_data(sp):
     # User Profile

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -26,3 +26,9 @@ def test_login_redirects(client):
     response = client.get('/login')
     assert response.status_code == 302
     assert 'accounts.spotify.com' in response.headers['Location']
+
+
+def test_protected_route_redirects_without_token(client):
+    response = client.get('/user')
+    assert response.status_code == 302
+    assert '/login' in response.headers['Location']


### PR DESCRIPTION
## Summary
- store the Spotify OAuth token in the Flask session during authorization and reuse it for client creation
- refresh stored tokens when expired before building the Spotipy client
- redirect protected Spotify routes to the login flow when no token is available and extend route tests for the guard

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0985ba5a88331ad2ad2a53b42063f