### PR TITLE
Use package-qualified imports for app modules

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -3,18 +3,18 @@ import spotipy
 from dotenv import load_dotenv
 from authlib.integrations.flask_client import OAuth
 from flask import Flask, redirect, request, url_for
-from spotify_api_services import (
+from .spotify_api_services import (
     get_user, get_user_playlists, get_playlist, get_playlist_items,
     get_playlist_cover_image, get_track, get_several_tracks, get_saved_tracks,
     get_several_audio_features, get_track_audio_features,
     get_track_audio_analysis, get_user_top_items, get_followed_artists,
 )
-from spotify_utils import (
+from .spotify_utils import (
     print_playlist_structure, print_playlist_items_structure, print_cover_image_structure, print_structure
 )
-from database import init_database, db_session
-from models import User
-from data_access import SpotifyDataAccess
+from .database import init_database, db_session
+from .models import User
+from .data_access import SpotifyDataAccess
 
 # Load environment variables from .env file
 load_dotenv()

--- a/app/data_access.py
+++ b/app/data_access.py
@@ -7,12 +7,12 @@ import json
 from datetime import datetime
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
-from models import (
+from .models import (
     User, Artist, Album, Track, Playlist, AudioFeatures, AudioAnalysis,
     SavedTrack, UserTopTrack, UserTopArtist,
     playlist_track_association, track_artist_association, album_artist_association
 )
-from database import db_session
+from .database import db_session
 
 class SpotifyDataAccess:
     """Data access operations for Spotify entities."""

--- a/app/database.py
+++ b/app/database.py
@@ -6,7 +6,7 @@ import os
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from contextlib import contextmanager
-from models import Base
+from .models import Base
 
 class DatabaseManager:
     """Manages database connections and sessions."""

--- a/test_db.py
+++ b/test_db.py
@@ -5,15 +5,15 @@ Simple test to create database and check models
 import sys
 import os
 
-# Add paths
+# Ensure the project root is on the Python path for package imports
 project_root = os.path.dirname(__file__)
-app_dir = os.path.join(project_root, 'app')
-sys.path.insert(0, app_dir)
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
 
 print("Starting database test...")
 
 try:
-    from models import Base, User, Artist, Album, Track
+    from app.models import Base, User, Artist, Album, Track
     print("✓ Models imported successfully")
     
     from sqlalchemy import create_engine

--- a/test_phase1.py
+++ b/test_phase1.py
@@ -5,12 +5,13 @@ Simple database test to verify Phase 1 completion.
 import sys
 import os
 
-# Add the app directory to the Python path
-app_dir = os.path.join(os.path.dirname(__file__), 'app')
-sys.path.insert(0, app_dir)
+# Ensure the project root is on the Python path for package imports
+project_root = os.path.dirname(__file__)
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
 
-from database import db_session
-from models import User, Artist, Album, Track, Playlist, AudioFeatures
+from app.database import db_session
+from app.models import User, Artist, Album, Track, Playlist, AudioFeatures
 
 def test_basic_operations():
     """Test basic database operations."""


### PR DESCRIPTION
## Summary
- update Flask app and data layer modules to use package-relative imports for internal dependencies
- refresh database-related smoke tests to load modules via the package path so they remain compatible

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0985841148331b4cbcc8f10616dc3