### PR TITLE
Refactor Flask app to use factory pattern

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,1 +1,5 @@
-# Spotify MusiVault Application Package
+"""Spotify MusiVault application package."""
+
+from app.app import create_app
+
+__all__ = ["create_app"]

--- a/app/app.py
+++ b/app/app.py
@@ -1,351 +1,325 @@
-import os
+
+"""Flask application factory and routes for Spotify MusiVault."""
+
+from collections.abc import Mapping
 import time
+from typing import Any
 
 import spotipy
-from dotenv import load_dotenv
 from authlib.integrations.flask_client import OAuth
+from dotenv import load_dotenv
+from flask import Blueprint, Flask, current_app, redirect, request, session, url_for
 
-from flask import Flask, redirect, request, session, url_for
-from spotify_api_services import (
-    get_user, get_user_playlists, get_playlist, get_playlist_items,
-    get_playlist_cover_image, get_track, get_several_tracks, get_saved_tracks,
-    get_several_audio_features, get_track_audio_features,
-    get_track_audio_analysis, get_user_top_items, get_followed_artists,
+from app.config import validate_required_settings
+from app.data_access import SpotifyDataAccess
+from app.database import db_session, init_database
+from app.models import User
+from app.spotify_api_services import (
+    get_followed_artists,
+    get_playlist,
+    get_playlist_cover_image,
+    get_playlist_items,
+    get_saved_tracks,
+    get_several_audio_features,
+    get_several_tracks,
+    get_track,
+    get_track_audio_analysis,
+    get_track_audio_features,
+    get_user,
+    get_user_playlists,
+    get_user_top_items,
 )
-from .spotify_utils import (
-    print_playlist_structure, print_playlist_items_structure, print_cover_image_structure, print_structure
-)
-from .database import init_database, db_session
-from .models import User
-from .data_access import SpotifyDataAccess
+from app.spotify_utils import print_structure
 
-# Load environment variables from .env file
-load_dotenv()
 
-app = Flask(__name__)
+bp = Blueprint("main", __name__)
 
-# Initialize database on startup
-try:
-    init_database()
-    print("Database ready!")
-except Exception as e:
-    print(f"Database initialization warning: {e}")
 
-# Use the secret key from the .env file
-app.secret_key = os.getenv('APP_SECRET_KEY')
-
-oauth = OAuth(app)
-spotify = oauth.register(
-    name='spotify',
-    client_id=os.getenv('SPOTIFY_CLIENT_ID'),
-    client_secret=os.getenv('SPOTIFY_CLIENT_SECRET'),
-    access_token_url='https://accounts.spotify.com/api/token',
-    access_token_params=None,
-    authorize_url='https://accounts.spotify.com/authorize',
-    authorize_params=None,
-    api_base_url='https://api.spotify.com/v1/',
-    client_kwargs={'scope': 'playlist-read-private playlist-read-collaborative user-top-read user-follow-read user-library-read'},
-)
-
-@app.route('/')
+@bp.route("/")
 def index():
-    return redirect(url_for('login'))
+    return redirect(url_for("main.login"))
 
-@app.route('/login')
+
+@bp.route("/login")
 def login():
-    redirect_uri = url_for('authorize', _external=True)
-    return spotify.authorize_redirect(redirect_uri)
+    spotify_oauth = current_app.extensions["spotify_oauth_client"]
+    redirect_uri = url_for("main.authorize", _external=True)
+    return spotify_oauth.authorize_redirect(redirect_uri)
 
-@app.route('/authorize')
+
+@bp.route("/authorize")
 def authorize():
-    token_info = spotify.authorize_access_token()
+    spotify_oauth = current_app.extensions["spotify_oauth_client"]
+    token_info = spotify_oauth.authorize_access_token()
     if token_info is None:
-        return redirect(url_for('login'))
+        return redirect(url_for("main.login"))
 
     token_info = token_info.copy()
-    if 'expires_at' not in token_info:
-        expires_in = token_info.get('expires_in')
+    if "expires_at" not in token_info:
+        expires_in = token_info.get("expires_in")
         if expires_in is not None:
-            token_info['expires_at'] = int(time.time()) + int(expires_in)
+            token_info["expires_at"] = int(time.time()) + int(expires_in)
 
-    session['spotify_token'] = token_info
+    session["spotify_token"] = token_info
 
-    sp = spotipy.Spotify(auth=token_info['access_token'])
+    sp = spotipy.Spotify(auth=token_info["access_token"])
 
-    # Fetch and print all Spotify data
     fetch_and_print_spotify_data(sp)
 
     profile = sp.current_user()
-    return 'Logged in as ' + profile['id']
+    return "Logged in as " + profile["id"]
 
-# @app.route('/authorize')
-# def authorize():
-#     token_info = spotify.authorize_access_token()
-    
-#     # Creating a Spotipy client with the access token
-#     sp = spotipy.Spotify(auth=token_info['access_token'])
 
-#     # Fetch and log the user's playlists
-#     playlists = sp.current_user_playlists()
-#     while playlists:
-#         for i, playlist in enumerate(playlists['items']):
-#             print(f"{i + playlists['offset']} - {playlist['name']}")
-#         if playlists['next']:
-#             playlists = sp.next(playlists)
-#         else:
-#             playlists = None
-    
-#     # Example of using a function from spotify_utils
-#     playlists = get_playlist_items(sp, 'some_playlist_id')
-
-#     profile = sp.current_user()
-#     # Do something with the profile, e.g., store in session or database
-#     return 'Logged in as ' + profile['id']
-
-@app.route('/user')
+@bp.route("/user")
 def user():
     sp = create_spotify_client()
     if sp is None:
-        return redirect(url_for('login'))
+        return redirect(url_for("main.login"))
     user_info = get_user(sp)
     return user_info
 
-@app.route('/user/playlists')
+
+@bp.route("/user/playlists")
 def user_playlists():
     sp = create_spotify_client()
     if sp is None:
-        return redirect(url_for('login'))
+        return redirect(url_for("main.login"))
     playlists = get_user_playlists(sp)
     return {"playlists": playlists}
 
-@app.route('/playlist/<playlist_id>')
+
+@bp.route("/playlist/<playlist_id>")
 def playlist(playlist_id):
     sp = create_spotify_client()
     if sp is None:
-        return redirect(url_for('login'))
+        return redirect(url_for("main.login"))
     playlist_info = get_playlist(sp, playlist_id)
     return playlist_info
 
-@app.route('/playlist/<playlist_id>/items')
+
+@bp.route("/playlist/<playlist_id>/items")
 def playlist_items(playlist_id):
     sp = create_spotify_client()
     if sp is None:
-        return redirect(url_for('login'))
+        return redirect(url_for("main.login"))
     items = get_playlist_items(sp, playlist_id)
     return {"items": items}
 
-@app.route('/playlist/<playlist_id>/cover')
+
+@bp.route("/playlist/<playlist_id>/cover")
 def playlist_cover(playlist_id):
     sp = create_spotify_client()
     if sp is None:
-        return redirect(url_for('login'))
+        return redirect(url_for("main.login"))
     cover_image = get_playlist_cover_image(sp, playlist_id)
     return {"cover_image": cover_image}
 
-@app.route('/track/<track_id>')
+
+@bp.route("/track/<track_id>")
 def track(track_id):
     sp = create_spotify_client()
     if sp is None:
-        return redirect(url_for('login'))
+        return redirect(url_for("main.login"))
     track_info = get_track(sp, track_id)
     return track_info
 
-@app.route('/tracks')
+
+@bp.route("/tracks")
 def several_tracks():
     sp = create_spotify_client()
     if sp is None:
-        return redirect(url_for('login'))
-    # Assuming track IDs are passed as query parameters
-    track_ids = request.args.getlist('ids')
+        return redirect(url_for("main.login"))
+    track_ids = request.args.getlist("ids")
     tracks_info = get_several_tracks(sp, track_ids)
     return {"tracks": tracks_info}
 
-@app.route('/user/saved_tracks')
+
+@bp.route("/user/saved_tracks")
 def saved_tracks():
     sp = create_spotify_client()
     if sp is None:
-        return redirect(url_for('login'))
+        return redirect(url_for("main.login"))
     tracks = get_saved_tracks(sp)
     return {"saved_tracks": tracks}
 
-@app.route('/audio_features')
+
+@bp.route("/audio_features")
 def audio_features():
     sp = create_spotify_client()
     if sp is None:
-        return redirect(url_for('login'))
-    # Assuming track IDs are passed as query parameters
-    track_ids = request.args.getlist('ids')
+        return redirect(url_for("main.login"))
+    track_ids = request.args.getlist("ids")
     features = get_several_audio_features(sp, track_ids)
     return {"audio_features": features}
 
-@app.route('/track/<track_id>/audio_features')
+
+@bp.route("/track/<track_id>/audio_features")
 def track_audio_features(track_id):
     sp = create_spotify_client()
     if sp is None:
-        return redirect(url_for('login'))
+        return redirect(url_for("main.login"))
     features = get_track_audio_features(sp, track_id)
     return {"audio_features": features}
 
-@app.route('/track/<track_id>/audio_analysis')
+
+@bp.route("/track/<track_id>/audio_analysis")
 def track_audio_analysis(track_id):
     sp = create_spotify_client()
     if sp is None:
-        return redirect(url_for('login'))
+        return redirect(url_for("main.login"))
     analysis = get_track_audio_analysis(sp, track_id)
     return analysis
 
-@app.route('/user/top/<type>')
+
+@bp.route("/user/top/<type>")
 def user_top_items(type):
     sp = create_spotify_client()
     if sp is None:
-        return redirect(url_for('login'))
+        return redirect(url_for("main.login"))
     top_items = get_user_top_items(sp, type)
     return {"top_items": top_items}
 
-@app.route('/user/followed_artists')
+
+@bp.route("/user/followed_artists")
 def followed_artists():
     sp = create_spotify_client()
     if sp is None:
-        return redirect(url_for('login'))
+        return redirect(url_for("main.login"))
     artists = get_followed_artists(sp)
     return {"followed_artists": artists}
 
-def create_spotify_client():
-    token_info = session.get('spotify_token')
-    if not token_info:
-        return None
 
-    expires_at = token_info.get('expires_at')
-    if expires_at is None:
-        expires_in = token_info.get('expires_in')
-        if expires_in is not None:
-            expires_at = int(time.time()) + int(expires_in)
-            token_info['expires_at'] = expires_at
-            session['spotify_token'] = token_info
-
-    if expires_at is not None and expires_at <= int(time.time()):
-        refresh_token = token_info.get('refresh_token')
-        if not refresh_token:
-            session.pop('spotify_token', None)
-            return None
-
-        refreshed_token = spotify.refresh_token(
-            spotify.access_token_url,
-            refresh_token=refresh_token,
-        )
-        if 'refresh_token' not in refreshed_token and refresh_token:
-            refreshed_token['refresh_token'] = refresh_token
-        if 'expires_at' not in refreshed_token:
-            expires_in = refreshed_token.get('expires_in')
-            if expires_in is not None:
-                refreshed_token['expires_at'] = int(time.time()) + int(expires_in)
-        session['spotify_token'] = refreshed_token
-        token_info = refreshed_token
-
-    access_token = token_info.get('access_token')
-    if not access_token:
-        session.pop('spotify_token', None)
-        return None
-
-    return spotipy.Spotify(auth=access_token)
-
-def fetch_and_print_spotify_data(sp):
-    # User Profile
-    user_info = get_user(sp)
-    print("User Info:", user_info)
-    # Prints: 
-    # User Info: {'display_name': 'mlgprettyboi', 'external_urls': 
-    # {'spotify': 'https://open.spotify.com/user/mlgprettyboi'}, 'href': 
-    # 'https://api.spotify.com/v1/users/mlgprettyboi', 'id': 'mlgprettyboi', 
-    # 'images': [], 'type': 'user', 'uri': 'spotify:user:mlgprettyboi', 
-    # 'followers': {'href': None, 'total': 3}}
-
-    # # User's Playlists
-    # playlists = get_user_playlists(sp)
-    # print("\nUser's Playlists:")
-    # for playlist in playlists:
-    #     print(playlist['name'])
-
-        # # Playlist Details
-        # playlist_detail = get_playlist(sp, playlist['id'])
-        # print("  Detail:")
-        # print_playlist_structure(playlist_detail)
-
-        # print("  Detail:", playlist_detail)
-
-        # # Playlist Items
-        # playlist_items = get_playlist_items(sp, playlist['id'])
-        # print("  Items:", playlist_items)
-
-        # # Open a file in write mode
-        # with open('playlist_items_structure.txt', 'w') as f:
-        #     # Call the function with the file parameter
-        #     print_playlist_items_structure(playlist_items, file=f)
-
-        # # Playlist Cover Image
-        # cover_image = get_playlist_cover_image(sp, playlist['id'])
-        # print_cover_image_structure(cover_image)
-        # # print("  Cover Image:", cover_image)
-
-    # # User's Saved Tracks
-    # saved_tracks = get_saved_tracks(sp)
-    # print(type("\nSaved Tracks: {saved_tracks}"))
-    # print(saved_tracks)
-
-    # User's Top Items (Tracks and Artists)
-    top_tracks = get_user_top_items(sp, 'tracks')
-    # print("\nTop Tracks:", top_tracks)
-    print_structure(top_tracks)
-    # top_artists = get_user_top_items(sp, 'artists')
-    # print("\nTop Artists:", top_artists)
-
-    # # Followed Artists
-    # followed_artists = get_followed_artists(sp)
-    # print("\nFollowed Artists:", followed_artists)
-
-    # # Fetching track details, audio features, and audio analysis for a few tracks
-    # # Assuming you have some track IDs
-    # sample_track_ids = ['track_id1', 'track_id2']
-    # tracks = get_several_tracks(sp, sample_track_ids)
-    # print("\nTracks Details:", tracks)
-    # for track_id in sample_track_ids:
-    #     track_audio_features = get_track_audio_features(sp, track_id)
-    #     print(f"\nAudio Features for {track_id}:", track_audio_features)
-    #     track_audio_analysis = get_track_audio_analysis(sp, track_id)
-    #     print(f"\nAudio Analysis for {track_id}:", track_audio_analysis)
-
-@app.route('/db-test')
+@bp.route("/db-test")
 def test_database():
     """Test database connectivity and basic operations."""
     try:
-        with db_session() as session:
-            # Try to query users table
-            user_count = session.query(User).count()
+        with db_session() as session_scope:
+            user_count = session_scope.query(User).count()
             return {
-                'status': 'success',
-                'message': 'Database connection successful',
-                'user_count': user_count
+                "status": "success",
+                "message": "Database connection successful",
+                "user_count": user_count,
             }
-    except Exception as e:
+    except Exception as exc:  # pragma: no cover - diagnostic path
         return {
-            'status': 'error',
-            'message': f'Database error: {str(e)}'
+            "status": "error",
+            "message": f"Database error: {str(exc)}",
         }, 500
 
-@app.route('/db-stats')
+
+@bp.route("/db-stats")
 def database_stats():
     """Get database statistics."""
     try:
         stats = SpotifyDataAccess.get_database_stats()
         return {
-            'status': 'success',
-            'stats': stats
+            "status": "success",
+            "stats": stats,
         }
-    except Exception as e:
+    except Exception as exc:  # pragma: no cover - diagnostic path
         return {
-            'status': 'error',
-            'message': f'Error retrieving stats: {str(e)}'
+            "status": "error",
+            "message": f"Error retrieving stats: {str(exc)}",
         }, 500
 
-if __name__ == '__main__':
-    app.run(debug=True)
+
+def create_spotify_client():
+    spotify_oauth = current_app.extensions.get("spotify_oauth_client")
+    if spotify_oauth is None:
+        raise RuntimeError("Spotify OAuth client has not been configured on the app.")
+
+    token_info = session.get("spotify_token")
+    if not token_info:
+        return None
+
+    expires_at = token_info.get("expires_at")
+    if expires_at is None:
+        expires_in = token_info.get("expires_in")
+        if expires_in is not None:
+            expires_at = int(time.time()) + int(expires_in)
+            token_info["expires_at"] = expires_at
+            session["spotify_token"] = token_info
+
+    if expires_at is not None and expires_at <= int(time.time()):
+        refresh_token = token_info.get("refresh_token")
+        if not refresh_token:
+            session.pop("spotify_token", None)
+            return None
+
+        refreshed_token = spotify_oauth.refresh_token(
+            spotify_oauth.access_token_url,
+            refresh_token=refresh_token,
+        )
+        if "refresh_token" not in refreshed_token and refresh_token:
+            refreshed_token["refresh_token"] = refresh_token
+        if "expires_at" not in refreshed_token:
+            expires_in = refreshed_token.get("expires_in")
+            if expires_in is not None:
+                refreshed_token["expires_at"] = int(time.time()) + int(expires_in)
+        session["spotify_token"] = refreshed_token
+        token_info = refreshed_token
+
+    access_token = token_info.get("access_token")
+    if not access_token:
+        session.pop("spotify_token", None)
+        return None
+
+    return spotipy.Spotify(auth=access_token)
+
+
+def fetch_and_print_spotify_data(sp):
+    user_info = get_user(sp)
+    print("User Info:", user_info)
+    top_tracks = get_user_top_items(sp, "tracks")
+    print_structure(top_tracks)
+
+
+def _configure_app(app: Flask, config_object: Any = None) -> None:
+    if config_object is not None:
+        if isinstance(config_object, Mapping):
+            app.config.update(config_object)
+        else:
+            app.config.from_object(config_object)
+
+
+def create_app(config_object: Any = None) -> Flask:
+    load_dotenv()
+    app = Flask(__name__)
+
+    _configure_app(app, config_object)
+
+    validated = validate_required_settings(app.config)
+    for key, value in validated.items():
+        app.config.setdefault(key, value)
+
+    app.secret_key = app.config["APP_SECRET_KEY"]
+
+    oauth = OAuth(app)
+    spotify_oauth = oauth.register(
+        name="spotify",
+        client_id=app.config["SPOTIFY_CLIENT_ID"],
+        client_secret=app.config["SPOTIFY_CLIENT_SECRET"],
+        access_token_url="https://accounts.spotify.com/api/token",
+        access_token_params=None,
+        authorize_url="https://accounts.spotify.com/authorize",
+        authorize_params=None,
+        api_base_url="https://api.spotify.com/v1/",
+        client_kwargs={
+            "scope": "playlist-read-private playlist-read-collaborative user-top-read user-follow-read user-library-read",
+        },
+    )
+    app.extensions["spotify_oauth_client"] = spotify_oauth
+
+    try:
+        init_database()
+        app.logger.info("Database ready!")
+    except Exception as exc:  # pragma: no cover - diagnostic path
+        app.logger.warning("Database initialization warning: %s", exc)
+
+    app.register_blueprint(bp)
+    return app
+
+
+if __name__ == "__main__":
+    application = create_app()
+    application.run(debug=True)

--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,73 @@
+"""Application configuration utilities."""
+
+from collections.abc import Mapping
+import os
+from typing import Any, Dict, Iterable, Optional
+
+REQUIRED_ENV_VARS: tuple[str, ...] = (
+    "SPOTIFY_CLIENT_ID",
+    "SPOTIFY_CLIENT_SECRET",
+    "APP_SECRET_KEY",
+)
+
+
+def _extract_from_source(source: Any, key: str) -> Optional[str]:
+    """Return a configuration value from a mapping or object."""
+    if source is None:
+        return None
+
+    if isinstance(source, Mapping):
+        value = source.get(key)
+        if value is not None:
+            return str(value)
+        return None
+
+    # Fallback to attribute access for objects
+    if hasattr(source, key):
+        value = getattr(source, key)
+        if value is not None:
+            return str(value)
+    return None
+
+
+def validate_required_settings(source: Any = None, required: Iterable[str] = REQUIRED_ENV_VARS) -> Dict[str, str]:
+    """Ensure required settings are available via configuration or environment.
+
+    Parameters
+    ----------
+    source:
+        Optional mapping/object containing configuration overrides.
+    required:
+        Iterable of setting names that must be available.
+
+    Returns
+    -------
+    Dict[str, str]
+        Mapping of validated configuration values.
+
+    Raises
+    ------
+    RuntimeError
+        If any required setting is missing.
+    """
+
+    resolved: Dict[str, str] = {}
+    missing: list[str] = []
+
+    for key in required:
+        value = _extract_from_source(source, key)
+        if value is None or value == "":
+            value = os.getenv(key)
+        if value is None or value == "":
+            missing.append(key)
+        else:
+            resolved[key] = value
+
+    if missing:
+        formatted = ", ".join(missing)
+        raise RuntimeError(
+            "Missing required environment variables: "
+            f"{formatted}. Ensure these values are configured before starting the app."
+        )
+
+    return resolved

--- a/app/data_access.py
+++ b/app/data_access.py
@@ -7,12 +7,12 @@ import json
 from datetime import datetime
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
-from .models import (
+from app.models import (
     User, Artist, Album, Track, Playlist, AudioFeatures, AudioAnalysis,
     SavedTrack, UserTopTrack, UserTopArtist,
     playlist_track_association, track_artist_association, album_artist_association
 )
-from .database import db_session
+from app.database import db_session
 
 class SpotifyDataAccess:
     """Data access operations for Spotify entities."""

--- a/app/database.py
+++ b/app/database.py
@@ -6,7 +6,7 @@ import os
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from contextlib import contextmanager
-from .models import Base
+from app.models import Base
 
 class DatabaseManager:
     """Manages database connections and sessions."""

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,7 +1,6 @@
-import os
-from importlib import reload
-
 import pytest
+
+from app import create_app
 
 
 @pytest.fixture
@@ -9,10 +8,11 @@ def client(monkeypatch):
     monkeypatch.setenv('SPOTIFY_CLIENT_ID', 'dummy')
     monkeypatch.setenv('SPOTIFY_CLIENT_SECRET', 'dummy')
     monkeypatch.setenv('APP_SECRET_KEY', 'testing-secret')
-    import app.app as app_module
-    reload(app_module)
-    app_module.app.config['TESTING'] = True
-    with app_module.app.test_client() as client:
+
+    app = create_app()
+    app.config['TESTING'] = True
+
+    with app.test_client() as client:
         yield client
 
 


### PR DESCRIPTION
## Summary
- refactor the Flask application into a factory-driven setup that registers routes via a blueprint and stores the Spotify OAuth client on the app
- add configuration validation utilities to ensure required Spotify credentials are present before initialization and expose the factory via the package
- update database/data access imports and tests to consume the factory and run against configured instances

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d09db4b9f883319077694a8330c344