### PR TITLE
Persist Spotify data and expose database-backed routes

### DIFF
--- a/app/data_access.py
+++ b/app/data_access.py
@@ -3,309 +3,545 @@ Data Access Layer (DAL) for Spotify MusiVault.
 Provides high-level database operations for Spotify data.
 """
 
+from __future__ import annotations
+
 import json
 from datetime import datetime
-from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import Session
+from typing import Any, Dict, Iterable, List, Optional, Type
+
+from sqlalchemy.orm import Session, joinedload
+
 from .models import (
-    User, Artist, Album, Track, Playlist, AudioFeatures, AudioAnalysis,
-    SavedTrack, UserTopTrack, UserTopArtist,
-    playlist_track_association, track_artist_association, album_artist_association
+    Album,
+    Artist,
+    AudioFeatures,
+    Playlist,
+    SavedTrack,
+    Track,
+    User,
+    UserTopArtist,
+    UserTopTrack,
 )
 from .database import db_session
+from .serializers import (
+    serialize_artist,
+    serialize_playlist,
+    serialize_saved_track,
+    serialize_track,
+    serialize_user,
+    serialize_user_top_artist,
+    serialize_user_top_track,
+)
+
+
+def _safe_json_dumps(value: Any) -> str:
+    """Serialize Python structures to JSON stored in the DB."""
+    if value is None:
+        return json.dumps([])
+    if isinstance(value, (dict, list)):
+        return json.dumps(value)
+    return json.dumps(value)
+
+
+def _parse_datetime(value: Optional[str]) -> Optional[datetime]:
+    """Parse Spotify timestamps into timezone-aware datetimes."""
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _get_from_identity_map(session: Session, model: Type[Any], pk: Any):
+    """Fetch an instance from the session identity map when available."""
+    identity_key = session.identity_key(model, pk)
+    return session.identity_map.get(identity_key)
+
+
+def _find_pending_instance(session: Session, model: Type[Any], pk: Any):
+    """Return a pending instance matching the given primary key."""
+    primary_keys = model.__mapper__.primary_key
+    if len(primary_keys) != 1:
+        return None
+    key_name = primary_keys[0].key
+    for instance in session.new:
+        if isinstance(instance, model) and getattr(instance, key_name) == pk:
+            return instance
+    return None
+
 
 class SpotifyDataAccess:
     """Data access operations for Spotify entities."""
-    
+
+    # ------------------------------------------------------------------
+    # Upsert helpers
+    # ------------------------------------------------------------------
+
     @staticmethod
-    def create_or_update_user(user_data: dict) -> dict:
-        """Create or update a user record."""
-        with db_session() as session:
-            user = session.query(User).filter(User.id == user_data['id']).first()
-            
-            if user:
-                # Update existing user
-                user.display_name = user_data.get('display_name')
-                user.email = user_data.get('email')
-                user.country = user_data.get('country')
-                user.followers_total = user_data.get('followers', {}).get('total', 0)
-                user.spotify_url = user_data.get('external_urls', {}).get('spotify')
-                user.href = user_data.get('href')
-                user.uri = user_data.get('uri')
-                user.product = user_data.get('product')
-                user.updated_at = datetime.utcnow()
-            else:
-                # Create new user
-                user = User(
-                    id=user_data['id'],
-                    display_name=user_data.get('display_name'),
-                    email=user_data.get('email'),
-                    country=user_data.get('country'),
-                    followers_total=user_data.get('followers', {}).get('total', 0),
-                    spotify_url=user_data.get('external_urls', {}).get('spotify'),
-                    href=user_data.get('href'),
-                    uri=user_data.get('uri'),
-                    product=user_data.get('product')
-                )
-                session.add(user)
-            
-            session.commit()
-            # Return a dictionary with the user data instead of the object
-            return {
-                'id': user.id,
-                'display_name': user.display_name,
-                'email': user.email,
-                'country': user.country,
-                'followers_total': user.followers_total,
-                'spotify_url': user.spotify_url,
-                'href': user.href,
-                'uri': user.uri,
-                'product': user.product
-            }
-    
+    def _ensure_user(session: Session, user_data: Dict[str, Any]) -> User:
+        user = session.get(User, user_data["id"])
+
+        if not user:
+            user = User(id=user_data["id"])
+            session.add(user)
+
+        user.display_name = user_data.get("display_name")
+        user.email = user_data.get("email")
+        user.country = user_data.get("country")
+        user.followers_total = user_data.get("followers", {}).get("total", 0)
+        user.spotify_url = user_data.get("external_urls", {}).get("spotify")
+        user.href = user_data.get("href")
+        user.uri = user_data.get("uri")
+        user.product = user_data.get("product")
+        user.updated_at = datetime.utcnow()
+
+        return user
+
     @staticmethod
-    def create_or_update_artist(artist_data: dict) -> dict:
-        """Create or update an artist record."""
-        with db_session() as session:
-            artist = session.query(Artist).filter(Artist.id == artist_data['id']).first()
-            
-            artist_dict = {
-                'id': artist_data['id'],
-                'name': artist_data['name'],
-                'genres': json.dumps(artist_data.get('genres', [])),
-                'popularity': artist_data.get('popularity'),
-                'followers_total': artist_data.get('followers', {}).get('total', 0),
-                'spotify_url': artist_data.get('external_urls', {}).get('spotify'),
-                'href': artist_data.get('href'),
-                'uri': artist_data.get('uri'),
-                'images': json.dumps(artist_data.get('images', []))
-            }
-            
+    def _ensure_artist(session: Session, artist_data: Dict[str, Any]) -> Optional[Artist]:
+        artist_id = artist_data.get("id")
+        if not artist_id:
+            return None
+
+        artist = (
+            _get_from_identity_map(session, Artist, artist_id)
+            or _find_pending_instance(session, Artist, artist_id)
+            or session.get(Artist, artist_id)
+        )
+        if not artist:
+            artist = Artist(id=artist_id)
+            session.add(artist)
+
+        artist.name = artist_data.get("name")
+        artist.genres = _safe_json_dumps(artist_data.get("genres", []))
+        artist.popularity = artist_data.get("popularity")
+        artist.followers_total = artist_data.get("followers", {}).get("total", 0)
+        artist.spotify_url = artist_data.get("external_urls", {}).get("spotify")
+        artist.href = artist_data.get("href")
+        artist.uri = artist_data.get("uri")
+        artist.images = _safe_json_dumps(artist_data.get("images", []))
+        artist.updated_at = datetime.utcnow()
+        return artist
+
+    @staticmethod
+    def _ensure_album(session: Session, album_data: Dict[str, Any]) -> Optional[Album]:
+        album_id = album_data.get("id")
+        if not album_id:
+            return None
+
+        album = (
+            _get_from_identity_map(session, Album, album_id)
+            or _find_pending_instance(session, Album, album_id)
+            or session.get(Album, album_id)
+        )
+        if not album:
+            album = Album(id=album_id)
+            session.add(album)
+
+        album.name = album_data.get("name")
+        album.album_type = album_data.get("album_type")
+        album.total_tracks = album_data.get("total_tracks")
+        album.release_date = album_data.get("release_date")
+        album.release_date_precision = album_data.get("release_date_precision")
+        album.available_markets = _safe_json_dumps(album_data.get("available_markets", []))
+        album.spotify_url = album_data.get("external_urls", {}).get("spotify")
+        album.href = album_data.get("href")
+        album.uri = album_data.get("uri")
+        album.images = _safe_json_dumps(album_data.get("images", []))
+        album.label = album_data.get("label")
+        album.popularity = album_data.get("popularity")
+        album.updated_at = datetime.utcnow()
+
+        album_artists = []
+        for artist_data in album_data.get("artists", []):
+            artist = SpotifyDataAccess._ensure_artist(session, artist_data)
             if artist:
-                # Update existing artist
-                for key, value in artist_dict.items():
-                    if key != 'id':
-                        setattr(artist, key, value)
-                artist.updated_at = datetime.utcnow()
-            else:
-                # Create new artist
-                artist = Artist(**artist_dict)
-                session.add(artist)
-            
-            session.commit()
-            return {
-                'id': artist.id,
-                'name': artist.name,
-                'genres': artist.genres,
-                'popularity': artist.popularity,
-                'followers_total': artist.followers_total,
-                'spotify_url': artist.spotify_url,
-                'href': artist.href,
-                'uri': artist.uri,
-                'images': artist.images
-            }
-    
+                album_artists.append(artist)
+        if album_artists:
+            album.artists = album_artists
+
+        return album
+
     @staticmethod
-    def create_or_update_album(album_data: dict) -> Album:
-        """Create or update an album record."""
-        with db_session() as session:
-            album = session.query(Album).filter(Album.id == album_data['id']).first()
-            
-            album_dict = {
-                'id': album_data['id'],
-                'name': album_data['name'],
-                'album_type': album_data.get('album_type'),
-                'total_tracks': album_data.get('total_tracks'),
-                'release_date': album_data.get('release_date'),
-                'release_date_precision': album_data.get('release_date_precision'),
-                'available_markets': json.dumps(album_data.get('available_markets', [])),
-                'spotify_url': album_data.get('external_urls', {}).get('spotify'),
-                'href': album_data.get('href'),
-                'uri': album_data.get('uri'),
-                'images': json.dumps(album_data.get('images', [])),
-                'label': album_data.get('label'),
-                'popularity': album_data.get('popularity')
-            }
-            
+    def _ensure_track(session: Session, track_data: Dict[str, Any]) -> Optional[Track]:
+        track_id = track_data.get("id")
+        if not track_id:
+            return None
+
+        track = (
+            _get_from_identity_map(session, Track, track_id)
+            or _find_pending_instance(session, Track, track_id)
+            or session.get(Track, track_id)
+        )
+        if not track:
+            track = Track(id=track_id)
+            session.add(track)
+
+        track.name = track_data.get("name")
+        track.duration_ms = track_data.get("duration_ms")
+        track.explicit = track_data.get("explicit", False)
+        track.popularity = track_data.get("popularity")
+        track.preview_url = track_data.get("preview_url")
+        track.track_number = track_data.get("track_number")
+        track.disc_number = track_data.get("disc_number", 1)
+        track.is_local = track_data.get("is_local", False)
+        track.available_markets = _safe_json_dumps(track_data.get("available_markets", []))
+        track.spotify_url = track_data.get("external_urls", {}).get("spotify")
+        track.href = track_data.get("href")
+        track.uri = track_data.get("uri")
+        track.external_ids = _safe_json_dumps(track_data.get("external_ids", {}))
+        track.updated_at = datetime.utcnow()
+
+        album_data = track_data.get("album")
+        if album_data:
+            album = SpotifyDataAccess._ensure_album(session, album_data)
             if album:
-                # Update existing album
-                for key, value in album_dict.items():
-                    if key != 'id':
-                        setattr(album, key, value)
-                album.updated_at = datetime.utcnow()
-            else:
-                # Create new album
-                album = Album(**album_dict)
-                session.add(album)
-            
-            session.commit()
+                track.album = album
+
+        artist_entities = []
+        for artist_data in track_data.get("artists", []):
+            artist = SpotifyDataAccess._ensure_artist(session, artist_data)
+            if artist:
+                artist_entities.append(artist)
+        if artist_entities:
+            track.artists = artist_entities
+
+        return track
+
+    # ------------------------------------------------------------------
+    # Public upsert helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def create_or_update_user(user_data: Dict[str, Any]) -> Dict[str, Any]:
+        with db_session() as session:
+            user = SpotifyDataAccess._ensure_user(session, user_data)
+            session.flush()
+            return serialize_user(user)
+
+    @staticmethod
+    def create_or_update_artist(artist_data: Dict[str, Any]) -> Dict[str, Any]:
+        with db_session() as session:
+            artist = SpotifyDataAccess._ensure_artist(session, artist_data)
+            session.flush()
+            return serialize_artist(artist) if artist else {}
+
+    @staticmethod
+    def create_or_update_album(album_data: Dict[str, Any]) -> Optional[Album]:
+        with db_session() as session:
+            album = SpotifyDataAccess._ensure_album(session, album_data)
+            session.flush()
             return album
-    
+
     @staticmethod
-    def create_or_update_track(track_data: dict, album_id=None) -> dict:
-        """Create or update a track record."""
+    def create_or_update_track(track_data: Dict[str, Any], album_id: Optional[str] = None) -> Dict[str, Any]:
         with db_session() as session:
-            track = session.query(Track).filter(Track.id == track_data['id']).first()
-            
-            track_dict = {
-                'id': track_data['id'],
-                'name': track_data['name'],
-                'duration_ms': track_data.get('duration_ms'),
-                'explicit': track_data.get('explicit', False),
-                'popularity': track_data.get('popularity'),
-                'preview_url': track_data.get('preview_url'),
-                'track_number': track_data.get('track_number'),
-                'disc_number': track_data.get('disc_number', 1),
-                'is_local': track_data.get('is_local', False),
-                'available_markets': json.dumps(track_data.get('available_markets', [])),
-                'spotify_url': track_data.get('external_urls', {}).get('spotify'),
-                'href': track_data.get('href'),
-                'uri': track_data.get('uri'),
-                'external_ids': json.dumps(track_data.get('external_ids', {})),
-                'album_id': album_id or track_data.get('album', {}).get('id')
-            }
-            
-            if track:
-                # Update existing track
-                for key, value in track_dict.items():
-                    if key != 'id':
-                        setattr(track, key, value)
-                track.updated_at = datetime.utcnow()
-            else:
-                # Create new track
-                track = Track(**track_dict)
-                session.add(track)
-            
-            session.commit()
-            return {
-                'id': track.id,
-                'name': track.name,
-                'duration_ms': track.duration_ms,
-                'explicit': track.explicit,
-                'popularity': track.popularity,
-                'preview_url': track.preview_url,
-                'track_number': track.track_number,
-                'disc_number': track.disc_number,
-                'is_local': track.is_local,
-                'album_id': track.album_id
-            }
-    
+            if album_id and "album" not in track_data:
+                track_data = dict(track_data)
+                track_data["album"] = {"id": album_id}
+            track = SpotifyDataAccess._ensure_track(session, track_data)
+            session.flush()
+            return serialize_track(track) if track else {}
+
     @staticmethod
-    def create_or_update_playlist(playlist_data: dict, owner_id: str) -> Playlist:
-        """Create or update a playlist record."""
+    def create_or_update_playlist(playlist_data: Dict[str, Any], owner_id: str) -> Playlist:
         with db_session() as session:
-            playlist = session.query(Playlist).filter(Playlist.id == playlist_data['id']).first()
-            
-            playlist_dict = {
-                'id': playlist_data['id'],
-                'name': playlist_data['name'],
-                'description': playlist_data.get('description'),
-                'public': playlist_data.get('public'),
-                'collaborative': playlist_data.get('collaborative', False),
-                'followers_total': playlist_data.get('followers', {}).get('total', 0),
-                'snapshot_id': playlist_data.get('snapshot_id'),
-                'spotify_url': playlist_data.get('external_urls', {}).get('spotify'),
-                'href': playlist_data.get('href'),
-                'uri': playlist_data.get('uri'),
-                'images': json.dumps(playlist_data.get('images', [])),
-                'primary_color': playlist_data.get('primary_color'),
-                'owner_id': owner_id
-            }
-            
-            if playlist:
-                # Update existing playlist
-                for key, value in playlist_dict.items():
-                    if key != 'id':
-                        setattr(playlist, key, value)
-                playlist.updated_at = datetime.utcnow()
-            else:
-                # Create new playlist
-                playlist = Playlist(**playlist_dict)
-                session.add(playlist)
-            
-            session.commit()
+            playlist = SpotifyDataAccess._ensure_playlist(session, playlist_data, owner_id)
+            session.flush()
             return playlist
-    
+
+    # ------------------------------------------------------------------
+    # Snapshot storage
+    # ------------------------------------------------------------------
+
     @staticmethod
-    def create_or_update_audio_features(features_data: dict) -> AudioFeatures:
-        """Create or update audio features for a track."""
+    def _ensure_playlist(session: Session, playlist_data: Dict[str, Any], owner_id: str) -> Playlist:
+        playlist_id = playlist_data["id"]
+        playlist = session.get(Playlist, playlist_id)
+        if not playlist:
+            playlist = Playlist(id=playlist_id, owner_id=owner_id)
+            session.add(playlist)
+
+        playlist.name = playlist_data.get("name")
+        playlist.description = playlist_data.get("description")
+        playlist.public = playlist_data.get("public")
+        playlist.collaborative = playlist_data.get("collaborative", False)
+        playlist.followers_total = playlist_data.get("followers", {}).get("total", 0)
+        playlist.snapshot_id = playlist_data.get("snapshot_id")
+        playlist.spotify_url = playlist_data.get("external_urls", {}).get("spotify")
+        playlist.href = playlist_data.get("href")
+        playlist.uri = playlist_data.get("uri")
+        playlist.images = _safe_json_dumps(playlist_data.get("images", []))
+        playlist.primary_color = playlist_data.get("primary_color")
+        playlist.updated_at = datetime.utcnow()
+        playlist.owner_id = owner_id
+        return playlist
+
+    @staticmethod
+    def _extract_time_range(top_payload: Any, default: str = "medium_term") -> str:
+        if isinstance(top_payload, dict):
+            if "time_range" in top_payload:
+                return top_payload["time_range"]
+            href = top_payload.get("href")
+            if href and "time_range=" in href:
+                return href.split("time_range=")[1].split("&")[0]
+        return default
+
+    @staticmethod
+    def store_user_snapshot(
+        user_data: Dict[str, Any],
+        playlists: Optional[Iterable[Dict[str, Any]]] = None,
+        saved_tracks: Optional[Iterable[Dict[str, Any]]] = None,
+        top_tracks: Optional[Any] = None,
+        top_artists: Optional[Any] = None,
+    ) -> str:
+        """Persist the current Spotify snapshot for a user."""
+
+        playlists = playlists or []
+        saved_tracks = saved_tracks or []
+
         with db_session() as session:
-            features = session.query(AudioFeatures).filter(
-                AudioFeatures.track_id == features_data['id']
-            ).first()
-            
-            features_dict = {
-                'track_id': features_data['id'],
-                'danceability': features_data.get('danceability'),
-                'energy': features_data.get('energy'),
-                'key': features_data.get('key'),
-                'loudness': features_data.get('loudness'),
-                'mode': features_data.get('mode'),
-                'speechiness': features_data.get('speechiness'),
-                'acousticness': features_data.get('acousticness'),
-                'instrumentalness': features_data.get('instrumentalness'),
-                'liveness': features_data.get('liveness'),
-                'valence': features_data.get('valence'),
-                'tempo': features_data.get('tempo'),
-                'time_signature': features_data.get('time_signature')
-            }
-            
-            if features:
-                # Update existing features
-                for key, value in features_dict.items():
-                    if key != 'track_id':
-                        setattr(features, key, value)
-                features.updated_at = datetime.utcnow()
+            user = SpotifyDataAccess._ensure_user(session, user_data)
+            session.flush()
+
+            SpotifyDataAccess._store_playlists(session, user, playlists)
+            session.flush()
+            SpotifyDataAccess._store_saved_tracks(session, user, saved_tracks)
+            session.flush()
+            SpotifyDataAccess._store_top_tracks(session, user, top_tracks)
+            SpotifyDataAccess._store_top_artists(session, user, top_artists)
+
+            return user.id
+
+    @staticmethod
+    def _store_playlists(session: Session, user: User, playlists: Iterable[Dict[str, Any]]) -> None:
+        playlist_entities: List[Playlist] = []
+        for payload in playlists:
+            if "playlist" in payload:
+                playlist_data = payload.get("playlist", {})
+                items = payload.get("items", [])
             else:
-                # Create new features
-                features = AudioFeatures(**features_dict)
-                session.add(features)
-            
-            session.commit()
-            return features
-    
+                playlist_data = payload
+                items = []
+
+            if "id" not in playlist_data:
+                continue
+
+            playlist = SpotifyDataAccess._ensure_playlist(session, playlist_data, user.id)
+            SpotifyDataAccess._store_playlist_items(session, playlist, items)
+            playlist_entities.append(playlist)
+
+        # Keep relationships consistent for SQLAlchemy session
+        if playlist_entities:
+            user.playlists = playlist_entities
+
     @staticmethod
-    def save_user_saved_track(user_id: str, track_data: dict, added_at=None):
-        """Save a user's saved track."""
+    def _store_playlist_items(session: Session, playlist: Playlist, items: Iterable[Dict[str, Any]]) -> None:
+        tracks: List[Track] = []
+        for item in items or []:
+            track_data = item.get("track") if isinstance(item, dict) else None
+            if not track_data:
+                continue
+            track = SpotifyDataAccess._ensure_track(session, track_data)
+            if track:
+                tracks.append(track)
+        if tracks:
+            playlist.tracks = tracks
+        else:
+            playlist.tracks = []
+
+    @staticmethod
+    def _store_saved_tracks(session: Session, user: User, saved_tracks: Iterable[Dict[str, Any]]) -> None:
+        session.query(SavedTrack).filter(SavedTrack.user_id == user.id).delete()
+        for item in saved_tracks or []:
+            track_data = item.get("track") if isinstance(item, dict) else None
+            if not track_data:
+                continue
+            track = SpotifyDataAccess._ensure_track(session, track_data)
+            if not track:
+                continue
+            added_at = _parse_datetime(item.get("added_at"))
+            saved_track = SavedTrack(user_id=user.id, track_id=track.id, added_at=added_at or datetime.utcnow())
+            session.add(saved_track)
+
+    @staticmethod
+    def _store_top_tracks(session: Session, user: User, payload: Any) -> None:
+        if payload is None:
+            session.query(UserTopTrack).filter(UserTopTrack.user_id == user.id).delete()
+            return
+
+        items = payload.get("items") if isinstance(payload, dict) else payload
+        if items is None:
+            items = []
+        time_range = SpotifyDataAccess._extract_time_range(payload)
+        session.query(UserTopTrack).filter(
+            UserTopTrack.user_id == user.id, UserTopTrack.time_range == time_range
+        ).delete()
+
+        for index, item in enumerate(items, start=1):
+            track = SpotifyDataAccess._ensure_track(session, item)
+            if not track:
+                continue
+            top_entry = UserTopTrack(
+                user_id=user.id,
+                track_id=track.id,
+                time_range=time_range,
+                rank=index,
+            )
+            session.add(top_entry)
+
+    @staticmethod
+    def _store_top_artists(session: Session, user: User, payload: Any) -> None:
+        if payload is None:
+            session.query(UserTopArtist).filter(UserTopArtist.user_id == user.id).delete()
+            return
+
+        items = payload.get("items") if isinstance(payload, dict) else payload
+        if items is None:
+            items = []
+        time_range = SpotifyDataAccess._extract_time_range(payload)
+        session.query(UserTopArtist).filter(
+            UserTopArtist.user_id == user.id, UserTopArtist.time_range == time_range
+        ).delete()
+
+        for index, item in enumerate(items, start=1):
+            artist = SpotifyDataAccess._ensure_artist(session, item)
+            if not artist:
+                continue
+            top_entry = UserTopArtist(
+                user_id=user.id,
+                artist_id=artist.id,
+                time_range=time_range,
+                rank=index,
+            )
+            session.add(top_entry)
+
+    # ------------------------------------------------------------------
+    # Retrieval helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def get_user(user_id: str) -> Optional[dict]:
         with db_session() as session:
-            # Check if already exists
-            existing = session.query(SavedTrack).filter(
-                SavedTrack.user_id == user_id,
-                SavedTrack.track_id == track_data['id']
-            ).first()
-            
-            if not existing:
-                saved_track = SavedTrack(
-                    user_id=user_id,
-                    track_id=track_data['id'],
-                    added_at=datetime.fromisoformat(added_at.replace('Z', '+00:00')) if added_at else datetime.utcnow()
+            user = session.get(User, user_id)
+            if not user:
+                return None
+            return serialize_user(user)
+
+    @staticmethod
+    def get_user_playlists(user_id: str) -> List[dict]:
+        with db_session() as session:
+            playlists = (
+                session.query(Playlist)
+                .options(
+                    joinedload(Playlist.tracks)
+                    .joinedload(Track.artists),
+                    joinedload(Playlist.tracks).joinedload(Track.album),
                 )
-                session.add(saved_track)
-                session.commit()
-    
+                .filter(Playlist.owner_id == user_id)
+                .all()
+            )
+            return [serialize_playlist(p, include_tracks=True) for p in playlists]
+
     @staticmethod
-    def get_user(user_id: str) -> User:
-        """Get a user by ID."""
+    def get_playlist(playlist_id: str) -> Optional[dict]:
         with db_session() as session:
-            return session.query(User).filter(User.id == user_id).first()
-    
+            playlist = (
+                session.query(Playlist)
+                .options(
+                    joinedload(Playlist.tracks)
+                    .joinedload(Track.artists),
+                    joinedload(Playlist.tracks).joinedload(Track.album),
+                )
+                .filter(Playlist.id == playlist_id)
+                .first()
+            )
+            if not playlist:
+                return None
+            return serialize_playlist(playlist, include_tracks=True)
+
     @staticmethod
-    def get_user_playlists(user_id: str) -> list:
-        """Get all playlists for a user."""
+    def get_saved_tracks(user_id: str) -> List[dict]:
         with db_session() as session:
-            return session.query(Playlist).filter(Playlist.owner_id == user_id).all()
-    
+            saved_tracks = (
+                session.query(SavedTrack)
+                .options(
+                    joinedload(SavedTrack.track).joinedload(Track.album),
+                    joinedload(SavedTrack.track).joinedload(Track.artists),
+                )
+                .filter(SavedTrack.user_id == user_id)
+                .order_by(SavedTrack.added_at.desc())
+                .all()
+            )
+            return [serialize_saved_track(st) for st in saved_tracks]
+
     @staticmethod
-    def get_database_stats() -> dict:
-        """Get database statistics."""
+    def get_user_top_tracks(user_id: str, time_range: Optional[str] = None) -> List[dict]:
         with db_session() as session:
-            stats = {
-                'users': session.query(User).count(),
-                'artists': session.query(Artist).count(),
-                'albums': session.query(Album).count(),
-                'tracks': session.query(Track).count(),
-                'playlists': session.query(Playlist).count(),
-                'audio_features': session.query(AudioFeatures).count(),
-                'saved_tracks': session.query(SavedTrack).count()
+            query = (
+                session.query(UserTopTrack)
+                .options(
+                    joinedload(UserTopTrack.track).joinedload(Track.album),
+                    joinedload(UserTopTrack.track).joinedload(Track.artists),
+                )
+                .filter(UserTopTrack.user_id == user_id)
+            )
+            if time_range:
+                query = query.filter(UserTopTrack.time_range == time_range)
+            entries = query.order_by(UserTopTrack.time_range, UserTopTrack.rank).all()
+            return [serialize_user_top_track(entry) for entry in entries]
+
+    @staticmethod
+    def get_user_top_artists(user_id: str, time_range: Optional[str] = None) -> List[dict]:
+        with db_session() as session:
+            query = (
+                session.query(UserTopArtist)
+                .options(joinedload(UserTopArtist.artist))
+                .filter(UserTopArtist.user_id == user_id)
+            )
+            if time_range:
+                query = query.filter(UserTopArtist.time_range == time_range)
+            entries = query.order_by(UserTopArtist.time_range, UserTopArtist.rank).all()
+            return [serialize_user_top_artist(entry) for entry in entries]
+
+    @staticmethod
+    def get_track(track_id: str) -> Optional[dict]:
+        with db_session() as session:
+            track = (
+                session.query(Track)
+                .options(joinedload(Track.album), joinedload(Track.artists))
+                .filter(Track.id == track_id)
+                .first()
+            )
+            if not track:
+                return None
+            return serialize_track(track)
+
+    @staticmethod
+    def get_tracks(track_ids: Iterable[str]) -> List[dict]:
+        ids = list(track_ids)
+        if not ids:
+            return []
+        with db_session() as session:
+            tracks = (
+                session.query(Track)
+                .options(joinedload(Track.album), joinedload(Track.artists))
+                .filter(Track.id.in_(ids))
+                .all()
+            )
+            tracks_by_id = {track.id: track for track in tracks}
+            return [serialize_track(tracks_by_id[track_id]) for track_id in ids if track_id in tracks_by_id]
+
+    @staticmethod
+    def get_database_stats() -> Dict[str, int]:
+        with db_session() as session:
+            return {
+                "users": session.query(User).count(),
+                "artists": session.query(Artist).count(),
+                "albums": session.query(Album).count(),
+                "tracks": session.query(Track).count(),
+                "playlists": session.query(Playlist).count(),
+                "audio_features": session.query(AudioFeatures).count(),
+                "saved_tracks": session.query(SavedTrack).count(),
             }
-            return stats

--- a/app/database.py
+++ b/app/database.py
@@ -13,6 +13,9 @@ class DatabaseManager:
     
     def __init__(self, database_url=None):
         if database_url is None:
+            database_url = os.getenv('DATABASE_URL')
+
+        if database_url is None:
             # Default to SQLite database in the project root
             db_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'spotify_data.db')
             database_url = f'sqlite:///{db_path}'

--- a/app/serializers.py
+++ b/app/serializers.py
@@ -1,0 +1,147 @@
+"""Serialization helpers for converting ORM objects into JSON-ready dicts."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, Iterable, List, Optional
+
+from .models import Album, Artist, Playlist, SavedTrack, Track, User, UserTopArtist, UserTopTrack
+
+
+def _deserialize_json(value: Optional[str], default: Any) -> Any:
+    if value is None:
+        return default
+    try:
+        return json.loads(value)
+    except (TypeError, json.JSONDecodeError):
+        return default
+
+
+def serialize_user(user: User) -> Dict[str, Any]:
+    return {
+        "id": user.id,
+        "display_name": user.display_name,
+        "email": user.email,
+        "country": user.country,
+        "followers_total": user.followers_total,
+        "spotify_url": user.spotify_url,
+        "href": user.href,
+        "uri": user.uri,
+        "product": user.product,
+    }
+
+
+def serialize_artist(artist: Artist) -> Dict[str, Any]:
+    return {
+        "id": artist.id,
+        "name": artist.name,
+        "genres": _deserialize_json(artist.genres, []),
+        "popularity": artist.popularity,
+        "followers_total": artist.followers_total,
+        "spotify_url": artist.spotify_url,
+        "href": artist.href,
+        "uri": artist.uri,
+        "images": _deserialize_json(artist.images, []),
+    }
+
+
+def serialize_album(album: Album) -> Dict[str, Any]:
+    return {
+        "id": album.id,
+        "name": album.name,
+        "album_type": album.album_type,
+        "total_tracks": album.total_tracks,
+        "release_date": album.release_date,
+        "release_date_precision": album.release_date_precision,
+        "available_markets": _deserialize_json(album.available_markets, []),
+        "spotify_url": album.spotify_url,
+        "href": album.href,
+        "uri": album.uri,
+        "images": _deserialize_json(album.images, []),
+        "label": album.label,
+        "popularity": album.popularity,
+        "artists": [serialize_artist(artist) for artist in album.artists],
+    }
+
+
+def serialize_track(track: Track) -> Dict[str, Any]:
+    return {
+        "id": track.id,
+        "name": track.name,
+        "duration_ms": track.duration_ms,
+        "explicit": track.explicit,
+        "popularity": track.popularity,
+        "preview_url": track.preview_url,
+        "track_number": track.track_number,
+        "disc_number": track.disc_number,
+        "is_local": track.is_local,
+        "available_markets": _deserialize_json(track.available_markets, []),
+        "spotify_url": track.spotify_url,
+        "href": track.href,
+        "uri": track.uri,
+        "external_ids": _deserialize_json(track.external_ids, {}),
+        "album": serialize_album(track.album) if track.album else None,
+        "artists": [serialize_artist(artist) for artist in track.artists],
+    }
+
+
+def serialize_playlist(playlist: Playlist, include_tracks: bool = False) -> Dict[str, Any]:
+    data = {
+        "id": playlist.id,
+        "name": playlist.name,
+        "description": playlist.description,
+        "public": playlist.public,
+        "collaborative": playlist.collaborative,
+        "followers_total": playlist.followers_total,
+        "snapshot_id": playlist.snapshot_id,
+        "spotify_url": playlist.spotify_url,
+        "href": playlist.href,
+        "uri": playlist.uri,
+        "images": _deserialize_json(playlist.images, []),
+        "primary_color": playlist.primary_color,
+        "owner_id": playlist.owner_id,
+    }
+    if include_tracks:
+        data["tracks"] = [serialize_track(track) for track in playlist.tracks]
+    return data
+
+
+def serialize_saved_track(saved_track: SavedTrack) -> Dict[str, Any]:
+    return {
+        "id": saved_track.id,
+        "user_id": saved_track.user_id,
+        "track": serialize_track(saved_track.track) if saved_track.track else None,
+        "added_at": saved_track.added_at.isoformat() if saved_track.added_at else None,
+    }
+
+
+def serialize_user_top_track(entry: UserTopTrack) -> Dict[str, Any]:
+    return {
+        "id": entry.id,
+        "user_id": entry.user_id,
+        "time_range": entry.time_range,
+        "rank": entry.rank,
+        "track": serialize_track(entry.track) if entry.track else None,
+    }
+
+
+def serialize_user_top_artist(entry: UserTopArtist) -> Dict[str, Any]:
+    return {
+        "id": entry.id,
+        "user_id": entry.user_id,
+        "time_range": entry.time_range,
+        "rank": entry.rank,
+        "artist": serialize_artist(entry.artist) if entry.artist else None,
+    }
+
+
+__all__ = [
+    "serialize_album",
+    "serialize_artist",
+    "serialize_playlist",
+    "serialize_saved_track",
+    "serialize_track",
+    "serialize_user",
+    "serialize_user_top_artist",
+    "serialize_user_top_track",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,24 @@
+from importlib import reload
+
+import pytest
+
+
+@pytest.fixture
+def app_environment(monkeypatch, tmp_path):
+    db_path = tmp_path / "test.db"
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+    monkeypatch.setenv('SPOTIFY_CLIENT_ID', 'dummy')
+    monkeypatch.setenv('SPOTIFY_CLIENT_SECRET', 'dummy')
+    monkeypatch.setenv('APP_SECRET_KEY', 'testing-secret')
+
+    import app.database as database_module
+    import app.data_access as data_access_module
+    import app.app as app_module
+
+    database_module = reload(database_module)
+    data_access_module = reload(data_access_module)
+    app_module = reload(app_module)
+    app_module.app.config['TESTING'] = True
+
+    with app_module.app.test_client() as client:
+        yield client, app_module, data_access_module

--- a/tests/test_data_access.py
+++ b/tests/test_data_access.py
@@ -1,0 +1,219 @@
+def build_spotify_payloads():
+    user = {
+        'id': 'user-123',
+        'display_name': 'Test User',
+        'email': 'user@example.com',
+        'country': 'US',
+        'followers': {'total': 42},
+        'external_urls': {'spotify': 'https://spotify.com/user-123'},
+        'href': 'https://api.spotify.com/v1/users/user-123',
+        'uri': 'spotify:user:user-123',
+        'product': 'premium',
+    }
+
+    artist_one = {
+        'id': 'artist-1',
+        'name': 'Artist One',
+        'genres': ['alt-rock'],
+        'followers': {'total': 1_000},
+        'images': [{'url': 'https://images/artist1.jpg'}],
+        'external_urls': {'spotify': 'https://spotify.com/artist-1'},
+        'href': 'https://api.spotify.com/v1/artists/artist-1',
+        'uri': 'spotify:artist:artist-1',
+        'popularity': 50,
+    }
+
+    artist_two = {
+        'id': 'artist-2',
+        'name': 'Artist Two',
+        'genres': ['pop'],
+        'followers': {'total': 2_000},
+        'images': [{'url': 'https://images/artist2.jpg'}],
+        'external_urls': {'spotify': 'https://spotify.com/artist-2'},
+        'href': 'https://api.spotify.com/v1/artists/artist-2',
+        'uri': 'spotify:artist:artist-2',
+        'popularity': 75,
+    }
+
+    album_one = {
+        'id': 'album-1',
+        'name': 'Album One',
+        'album_type': 'album',
+        'total_tracks': 10,
+        'release_date': '2024-01-01',
+        'release_date_precision': 'day',
+        'available_markets': ['US', 'GB'],
+        'external_urls': {'spotify': 'https://spotify.com/album-1'},
+        'href': 'https://api.spotify.com/v1/albums/album-1',
+        'uri': 'spotify:album:album-1',
+        'images': [{'url': 'https://images/album1.jpg'}],
+        'label': 'Indie Label',
+        'popularity': 60,
+        'artists': [artist_one],
+    }
+
+    album_two = {
+        'id': 'album-2',
+        'name': 'Album Two',
+        'album_type': 'single',
+        'total_tracks': 1,
+        'release_date': '2023-05-05',
+        'release_date_precision': 'day',
+        'available_markets': ['US'],
+        'external_urls': {'spotify': 'https://spotify.com/album-2'},
+        'href': 'https://api.spotify.com/v1/albums/album-2',
+        'uri': 'spotify:album:album-2',
+        'images': [{'url': 'https://images/album2.jpg'}],
+        'label': 'Major Label',
+        'popularity': 80,
+        'artists': [artist_two],
+    }
+
+    track_one = {
+        'id': 'track-1',
+        'name': 'Track One',
+        'duration_ms': 210000,
+        'explicit': False,
+        'popularity': 55,
+        'preview_url': 'https://preview/track1.mp3',
+        'track_number': 1,
+        'disc_number': 1,
+        'is_local': False,
+        'available_markets': ['US', 'GB'],
+        'external_urls': {'spotify': 'https://spotify.com/track-1'},
+        'href': 'https://api.spotify.com/v1/tracks/track-1',
+        'uri': 'spotify:track:track-1',
+        'external_ids': {'isrc': 'US1234567890'},
+        'album': album_one,
+        'artists': [artist_one],
+    }
+
+    track_two = {
+        'id': 'track-2',
+        'name': 'Track Two',
+        'duration_ms': 180000,
+        'explicit': True,
+        'popularity': 65,
+        'preview_url': 'https://preview/track2.mp3',
+        'track_number': 1,
+        'disc_number': 1,
+        'is_local': False,
+        'available_markets': ['US'],
+        'external_urls': {'spotify': 'https://spotify.com/track-2'},
+        'href': 'https://api.spotify.com/v1/tracks/track-2',
+        'uri': 'spotify:track:track-2',
+        'external_ids': {'isrc': 'US0987654321'},
+        'album': album_two,
+        'artists': [artist_two],
+    }
+
+    playlist = {
+        'id': 'playlist-1',
+        'name': 'Playlist One',
+        'description': 'A great playlist',
+        'public': True,
+        'collaborative': False,
+        'followers': {'total': 10},
+        'snapshot_id': 'snapshot-xyz',
+        'external_urls': {'spotify': 'https://spotify.com/playlist-1'},
+        'href': 'https://api.spotify.com/v1/playlists/playlist-1',
+        'uri': 'spotify:playlist:playlist-1',
+        'images': [{'url': 'https://images/playlist.jpg'}],
+        'primary_color': None,
+    }
+
+    playlist_items = [{'track': track_one}]
+    saved_tracks = [{'track': track_one, 'added_at': '2024-01-15T12:00:00Z'}]
+    top_tracks = {'items': [track_two], 'time_range': 'short_term'}
+    top_artists = {'items': [artist_one, artist_two], 'time_range': 'short_term'}
+
+    playlists_payload = [{'playlist': playlist, 'items': playlist_items}]
+
+    return user, playlists_payload, saved_tracks, top_tracks, top_artists
+
+
+def test_store_user_snapshot_persists_entities(app_environment):
+    _, app_module, data_access_module = app_environment
+    SpotifyDataAccess = data_access_module.SpotifyDataAccess
+
+    user, playlists, saved_tracks, top_tracks, top_artists = build_spotify_payloads()
+    user_id = SpotifyDataAccess.store_user_snapshot(
+        user, playlists=playlists, saved_tracks=saved_tracks, top_tracks=top_tracks, top_artists=top_artists
+    )
+
+    assert user_id == user['id']
+
+    stored_user = SpotifyDataAccess.get_user(user_id)
+    assert stored_user['display_name'] == 'Test User'
+    assert stored_user['followers_total'] == 42
+
+    playlists_data = SpotifyDataAccess.get_user_playlists(user_id)
+    assert len(playlists_data) == 1
+    playlist_data = playlists_data[0]
+    assert playlist_data['name'] == 'Playlist One'
+    assert playlist_data['tracks'][0]['artists'][0]['genres'] == ['alt-rock']
+    assert playlist_data['tracks'][0]['album']['available_markets'] == ['US', 'GB']
+
+    saved = SpotifyDataAccess.get_saved_tracks(user_id)
+    assert len(saved) == 1
+    saved_entry = saved[0]
+    assert saved_entry['track']['available_markets'] == ['US', 'GB']
+    assert saved_entry['added_at'].startswith('2024-01-15')
+
+    top_tracks_data = SpotifyDataAccess.get_user_top_tracks(user_id)
+    assert [entry['track']['id'] for entry in top_tracks_data] == ['track-2']
+    assert top_tracks_data[0]['track']['available_markets'] == ['US']
+
+    top_artists_data = SpotifyDataAccess.get_user_top_artists(user_id)
+    assert [entry['artist']['id'] for entry in top_artists_data] == ['artist-1', 'artist-2']
+    assert top_artists_data[0]['artist']['genres'] == ['alt-rock']
+
+
+def test_sync_service_populates_routes(monkeypatch, app_environment):
+    client, app_module, data_access_module = app_environment
+    SpotifyDataAccess = data_access_module.SpotifyDataAccess
+
+    user, playlists, saved_tracks, top_tracks, top_artists = build_spotify_payloads()
+
+    playlist_map = {payload['playlist']['id']: payload['items'] for payload in playlists}
+
+    monkeypatch.setattr(app_module, 'get_user', lambda sp: user)
+    monkeypatch.setattr(app_module, 'get_user_playlists', lambda sp: [payload['playlist'] for payload in playlists])
+    monkeypatch.setattr(
+        app_module, 'get_playlist_items', lambda sp, playlist_id: playlist_map.get(playlist_id, [])
+    )
+    monkeypatch.setattr(app_module, 'get_saved_tracks', lambda sp: saved_tracks)
+    monkeypatch.setattr(
+        app_module,
+        'get_user_top_items',
+        lambda sp, item_type: top_tracks if item_type == 'tracks' else top_artists,
+    )
+
+    user_id = app_module.sync_spotify_data(None)
+    assert user_id == user['id']
+
+    with client.session_transaction() as session:
+        session['current_user_id'] = user_id
+
+    response = client.get('/user')
+    assert response.status_code == 200
+    assert response.get_json()['user']['display_name'] == 'Test User'
+
+    playlists_response = client.get('/user/playlists')
+    assert playlists_response.status_code == 200
+    playlists_payload = playlists_response.get_json()['playlists']
+    assert playlists_payload[0]['tracks'][0]['artists'][0]['genres'] == ['alt-rock']
+
+    saved_response = client.get('/user/saved_tracks')
+    assert saved_response.status_code == 200
+    assert saved_response.get_json()['saved_tracks'][0]['track']['available_markets'] == ['US', 'GB']
+
+    top_tracks_response = client.get('/user/top/tracks')
+    assert top_tracks_response.status_code == 200
+    assert top_tracks_response.get_json()['top_items'][0]['track']['id'] == 'track-2'
+
+    playlist_id = playlists[0]['playlist']['id']
+    playlist_detail = client.get(f'/playlist/{playlist_id}')
+    assert playlist_detail.status_code == 200
+    assert playlist_detail.get_json()['id'] == playlist_id
+    assert playlist_detail.get_json()['tracks'][0]['album']['images'][0]['url'] == 'https://images/album1.jpg'

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,19 +1,9 @@
-import os
-from importlib import reload
-
 import pytest
 
-
 @pytest.fixture
-def client(monkeypatch):
-    monkeypatch.setenv('SPOTIFY_CLIENT_ID', 'dummy')
-    monkeypatch.setenv('SPOTIFY_CLIENT_SECRET', 'dummy')
-    monkeypatch.setenv('APP_SECRET_KEY', 'testing-secret')
-    import app.app as app_module
-    reload(app_module)
-    app_module.app.config['TESTING'] = True
-    with app_module.app.test_client() as client:
-        yield client
+def client(app_environment):
+    client, _, _ = app_environment
+    return client
 
 
 def test_index_redirects_to_login(client):


### PR DESCRIPTION
## Summary
- synchronize Spotify user data into the database during authorization and expose routes that serve structured JSON from persisted records
- expand the data access layer with helpers for storing playlists, saved tracks, and top artists/tracks alongside JSON deserialization utilities
- add serialization helpers and tests that seed fake Spotipy payloads to validate persistence and route responses

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d09db84e588331af57ff75fc4481b8